### PR TITLE
At86rf215

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -227,7 +227,7 @@ static void _block_while_busy(at86rf215_t *dev)
     gpio_irq_disable(dev->params.int_pin);
 
     do {
-        if (gpio_read(dev->params.int_pin) || dev->ack_timeout) {
+        if (gpio_read(dev->params.int_pin) || dev->timeout) {
             at86rf215_driver.isr((netdev_t *) dev);
         }
         /* allow the other interface to process events */

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -155,10 +155,10 @@ void at86rf215_reset(at86rf215_t *dev)
     uint64_t long_addr;
     memcpy(&long_addr, dev->netdev.long_addr, sizeof(long_addr));
     at86rf215_set_addr_long(dev, long_addr);
-    at86rf215_set_addr_short(dev, unaligned_get_u16(dev->netdev.short_addr));
+    at86rf215_set_addr_short(dev, 0, unaligned_get_u16(dev->netdev.short_addr));
 
     /*** set default PAN id ***/
-    at86rf215_set_pan(dev, dev->netdev.pan);
+    at86rf215_set_pan(dev, 0, dev->netdev.pan);
 
     /* set default TX power */
     at86rf215_set_txpower(dev, AT86RF215_DEFAULT_TXPOWER);

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -89,6 +89,8 @@ void at86rf215_reset_cfg(at86rf215_t *dev)
     /* set default options */
     dev->retries_max = 3;
     dev->csma_retries_max = 4;
+    dev->csma_maxbe = 5;
+    dev->csma_minbe = 3;
 
     dev->flags |= AT86RF215_OPT_AUTOACK
                |  AT86RF215_OPT_CSMA;

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -275,7 +275,9 @@ int at86rf215_tx_exec(at86rf215_t *dev)
 
     dev->flags |= AT86RF215_OPT_TX_PENDING;
     if (dev->flags & AT86RF215_OPT_CSMA) {
-        dev->flags |= AT86RF215_OPT_CCA_PENDING;
+	 if (!(dev->flags & AT86RF215_OPT_CCATX)) {
+            dev->flags |= AT86RF215_OPT_CCA_PENDING;
+         }
     }
 
     if (dev->state == AT86RF215_STATE_IDLE) {

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -31,7 +31,8 @@
 
 uint16_t at86rf215_get_addr_short(const at86rf215_t *dev)
 {
-    return at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0);
+	return (uint16_t)byteorder_ntohs((network_uint16_t)at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0));
+
 }
 uint16_t at86rf215_get_addr_short_multi(const at86rf215_t *dev, uint8_t filter)
 {
@@ -45,8 +46,8 @@ void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr)
 {
     dev->netdev.short_addr[0] = (uint8_t)(addr);
     dev->netdev.short_addr[1] = (uint8_t)(addr >> 8);
-
-    at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0, addr);
+    
+    at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0, byteorder_htons(addr).u16);
 }
 
 void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t addr)

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -57,6 +57,22 @@ void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t a
     at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter), addr);
 }
 
+uint8_t at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter)
+{
+	return (at86rf215_reg_read(dev, dev->BBC->RG_AFC0) >> (AFC0_AFEN0_SHIFT + filter)) & 1;
+}
+
+void at86rf215_set_framefilter_enabled(at86rf215_t *dev, uint8_t filter, uint8_t state)
+{
+	uint8_t val = at86rf215_reg_read(dev, dev->BBC->RG_AFC0);
+	if (state == 1){
+		val |= 1 << (AFC0_AFEN0_SHIFT + filter);
+	}else if (state == 0){
+		val &= ~(1 << (AFC0_AFEN0_SHIFT + filter));
+	}
+
+	return at86rf215_reg_write(dev, dev->BBC->RG_AFC0, val);
+}
 
 uint64_t at86rf215_get_addr_long(const at86rf215_t *dev)
 {

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -33,6 +33,13 @@ uint16_t at86rf215_get_addr_short(const at86rf215_t *dev)
 {
     return at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0);
 }
+uint16_t at86rf215_get_addr_short_multi(const at86rf215_t *dev, uint8_t filter)
+{
+    if (filter > 3){
+        return 0; 
+    }
+    return at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter));
+}
 
 void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr)
 {
@@ -41,6 +48,15 @@ void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr)
 
     at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0, addr);
 }
+
+void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t addr)
+{
+    if (filter > 3){
+	return; 
+    }
+    at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter), addr);
+}
+
 
 uint64_t at86rf215_get_addr_long(const at86rf215_t *dev)
 {
@@ -102,10 +118,26 @@ uint16_t at86rf215_get_pan(const at86rf215_t *dev)
     return at86rf215_reg_read16(dev, dev->BBC->RG_MACPID0F0);
 }
 
+uint16_t at86rf215_get_pan_multi(const at86rf215_t *dev, uint8_t filter)
+{
+	if (filter > 3){
+		return 0;
+	}
+	return at86rf215_reg_read16(dev, dev->BBC->RG_MACPID0F0 + (4 * filter));
+}
+
 void at86rf215_set_pan(at86rf215_t *dev, uint16_t pan)
 {
     dev->netdev.pan = pan;
     at86rf215_reg_write16(dev, dev->BBC->RG_MACPID0F0, pan);
+}
+
+void at86rf215_set_pan_multi(at86rf215_t *dev, uint8_t filter, uint16_t pan)
+{
+	if (filter > 3){
+		return;
+	}
+	at86rf215_reg_write16(dev, dev->BBC->RG_MACPID0F0 + (4*filter), pan);
 }
 
 // TODO: take modulation into account

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -277,6 +277,14 @@ void at86rf215_set_option(at86rf215_t *dev, uint16_t option, bool state)
             }
 
             break;
+        case AT86RF215_OPT_CCATX:
+            if (state){
+                at86rf215_reg_or(dev, dev->BBC->RG_AMCS, AMCS_CCATX_MASK);
+            } else {
+                at86rf215_reg_and(dev, dev->BBC->RG_AMCS, ~AMCS_CCATX_MASK);
+            }
+
+            break;
         case AT86RF215_OPT_RPC:
             if (state) {
                 at86rf215_enable_rpc(dev);

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -31,7 +31,7 @@
 
 uint16_t at86rf215_get_addr_short(const at86rf215_t *dev)
 {
-	return (uint16_t)byteorder_ntohs((network_uint16_t)at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0));
+    return (uint16_t)byteorder_ntohs((network_uint16_t)at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0));
 
 }
 uint16_t at86rf215_get_addr_short_multi(const at86rf215_t *dev, uint8_t filter)
@@ -53,26 +53,26 @@ void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr)
 void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t addr)
 {
     if (filter > 3){
-	return; 
+        return; 
     }
     at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter), byteorder_htons(addr).u16);
 }
 
 uint8_t at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter)
 {
-	return (at86rf215_reg_read(dev, dev->BBC->RG_AFC0) >> (AFC0_AFEN0_SHIFT + filter)) & 1;
+    return (at86rf215_reg_read(dev, dev->BBC->RG_AFC0) >> (AFC0_AFEN0_SHIFT + filter)) & 1;
 }
 
 void at86rf215_set_framefilter_enabled(at86rf215_t *dev, uint8_t filter, uint8_t state)
 {
-	uint8_t val = at86rf215_reg_read(dev, dev->BBC->RG_AFC0);
-	if (state == 1){
-		val |= 1 << (AFC0_AFEN0_SHIFT + filter);
-	}else if (state == 0){
-		val &= ~(1 << (AFC0_AFEN0_SHIFT + filter));
-	}
+    uint8_t val = at86rf215_reg_read(dev, dev->BBC->RG_AFC0);
+    if (state == 1){
+        val |= 1 << (AFC0_AFEN0_SHIFT + filter);
+    }else if (state == 0){
+        val &= ~(1 << (AFC0_AFEN0_SHIFT + filter));
+    }
 
-	return at86rf215_reg_write(dev, dev->BBC->RG_AFC0, val);
+    return at86rf215_reg_write(dev, dev->BBC->RG_AFC0, val);
 }
 
 uint64_t at86rf215_get_addr_long(const at86rf215_t *dev)
@@ -138,7 +138,7 @@ uint16_t at86rf215_get_pan(const at86rf215_t *dev)
 uint16_t at86rf215_get_pan_multi(const at86rf215_t *dev, uint8_t filter)
 {
 	if (filter > 3){
-		return 0;
+            return 0;
 	}
 	return at86rf215_reg_read16(dev, dev->BBC->RG_MACPID0F0 + (4 * filter));
 }
@@ -152,7 +152,7 @@ void at86rf215_set_pan(at86rf215_t *dev, uint16_t pan)
 void at86rf215_set_pan_multi(at86rf215_t *dev, uint8_t filter, uint16_t pan)
 {
 	if (filter > 3){
-		return;
+            return;
 	}
 	at86rf215_reg_write16(dev, dev->BBC->RG_MACPID0F0 + (4*filter), pan);
 }

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -50,21 +50,19 @@ void at86rf215_set_addr_short(at86rf215_t *dev, uint8_t filter, uint16_t addr)
     at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter), byteorder_htons(addr).u16);
 }
 
-uint8_t at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter)
+bool at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter)
 {
-    return (at86rf215_reg_read(dev, dev->BBC->RG_AFC0) >> (AFC0_AFEN0_SHIFT + filter)) & 1;
+    return (bool)((at86rf215_reg_read(dev, dev->BBC->RG_AFC0) >> (AFC0_AFEN0_SHIFT + filter)) & 1);
 }
 
-void at86rf215_set_framefilter_enabled(at86rf215_t *dev, uint8_t filter, uint8_t state)
+void at86rf215_enable_framefilter(at86rf215_t *dev, uint8_t filter)
 {
-    uint8_t val = at86rf215_reg_read(dev, dev->BBC->RG_AFC0);
-    if (state == 1){
-        val |= 1 << (AFC0_AFEN0_SHIFT + filter);
-    }else if (state == 0){
-        val &= ~(1 << (AFC0_AFEN0_SHIFT + filter));
-    }
+    at86rf215_reg_or(dev, dev->BBC->RG_AFC0, 1 << (AFC0_AFEN0_SHIFT + filter));
+}
 
-    return at86rf215_reg_write(dev, dev->BBC->RG_AFC0, val);
+void at86rf215_disable_framefilter(at86rf215_t *dev, uint8_t filter)
+{
+    at86rf215_reg_and(dev, dev->BBC->RG_AFC0, 1 << (AFC0_AFEN0_SHIFT + filter));
 }
 
 uint64_t at86rf215_get_addr_long(const at86rf215_t *dev)

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -34,7 +34,7 @@ uint16_t at86rf215_get_addr_short(const at86rf215_t *dev, uint8_t filter)
     if (filter > 3){
         return 0; 
     }
-    return byteorder_ntohs((network_uint16_t)at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter)));
+    return ntohs(at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter)));
 
 }
 

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -39,7 +39,7 @@ uint16_t at86rf215_get_addr_short_multi(const at86rf215_t *dev, uint8_t filter)
     if (filter > 3){
         return 0; 
     }
-    return at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter));
+    return byteorder_ntohs((network_uint16_t)at86rf215_reg_read16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter)));
 }
 
 void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr)
@@ -55,7 +55,7 @@ void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t a
     if (filter > 3){
 	return; 
     }
-    at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter), addr);
+    at86rf215_reg_write16(dev, dev->BBC->RG_MACSHA0F0 + (4*filter), byteorder_htons(addr).u16);
 }
 
 uint8_t at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter)

--- a/drivers/at86rf215/at86rf215_internal.c
+++ b/drivers/at86rf215/at86rf215_internal.c
@@ -131,6 +131,7 @@ void at86rf215_filter_ack(at86rf215_t *dev, bool on)
 
 void at86rf215_get_random(at86rf215_t *dev, uint8_t *data, size_t len)
 {
+    uint8_t state = at86rf215_reg_read(dev, dev->BBC->RG_PC);
     at86rf215_disable_baseband(dev);
 
     uint8_t rxbwc = at86rf215_reg_read(dev, dev->RF->RG_RXBWC);
@@ -144,7 +145,9 @@ void at86rf215_get_random(at86rf215_t *dev, uint8_t *data, size_t len)
     }
 
     at86rf215_reg_write(dev, dev->RF->RG_RXBWC, rxbwc);
-    at86rf215_enable_baseband(dev);
+    /* set baseband in prior state */
+    at86rf215_reg_write(dev, dev->BBC->RG_PC, state);
+
 }
 
 uint16_t at86rf215_chan_valid(at86rf215_t *dev, uint16_t chan)

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -1051,6 +1051,7 @@ static void _isr(netdev_t *netdev)
     /* This should never happen */
     if (++iter > 3) {
         puts("AT86RF215: stuck in ISR");
+        printf("\tnum_channels: %d\n", dev->num_chans);
         printf("\tHW: %s\n", at86rf215_hw_state2a(at86rf215_get_rf_state(dev)));
         printf("\tSW: %s\n", at86rf215_sw_state2a(dev->state));
         printf("\trf_irq_mask: %x\n", rf_irq_mask);

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -821,7 +821,7 @@ static void _backoff_timeout_cb(void* arg) {
     at86rf215_t *dev = arg;
     if (!(dev->flags & AT86RF215_OPT_CCATX)) {
         at86rf215_reg_write(dev, dev->RF->RG_EDC, 1);
-    }else{
+    } else {
         at86rf215_rf_cmd(dev, CMD_RF_TXPREP);
     }
 }

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -473,7 +473,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(len <= sizeof(uint16_t));
-            at86rf215_set_addr_short(dev, *((const uint16_t *)val));
+            at86rf215_set_addr_short(dev, 0, *((const uint16_t *)val));
             /* don't set res to set netdev_ieee802154_t::short_addr */
             break;
         case NETOPT_ADDRESS_LONG:
@@ -483,7 +483,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             break;
         case NETOPT_NID:
             assert(len <= sizeof(uint16_t));
-            at86rf215_set_pan(dev, *((const uint16_t *)val));
+            at86rf215_set_pan(dev, 0, *((const uint16_t *)val));
             /* don't set res to set netdev_ieee802154_t::pan */
             break;
         case NETOPT_CHANNEL:

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -884,7 +884,9 @@ static void _handle_ack_timeout(at86rf215_t *dev)
 
         if (dev->flags & AT86RF215_OPT_CSMA) {
             dev->csma_retries = dev->csma_retries_max;
-            dev->flags |= AT86RF215_OPT_CCA_PENDING;
+            if (!(dev->flags & AT86RF215_OPT_CCATX)){
+                dev->flags |= AT86RF215_OPT_CCA_PENDING;
+            }
         }
 
         dev->flags |= AT86RF215_OPT_TX_PENDING;
@@ -1157,7 +1159,7 @@ timeout:
             DEBUG("Ack timeout postponed\n");
             _start_ack_timer(dev);
         } else {
-            DEBUG("Ack timeout");
+            DEBUG("Ack timeout\n");
             _handle_ack_timeout(dev);
         }
 

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -1138,6 +1138,7 @@ static void _isr(netdev_t *netdev)
 
         if (_ack_frame_received(dev)) {
             xtimer_remove(&dev->ack_timer);
+            dev->ack_timeout = false; // we got an ACK so we can forget this timeout
             _tx_end(dev, NETDEV_EVENT_TX_COMPLETE);
             at86rf215_rf_cmd(dev, CMD_RF_RX);
             break;

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -859,8 +859,8 @@ static void _start_backoff_timer(at86rf215_t *dev)
     }
 
     uint32_t csma_backoff_usec = (((uint32_t)1 << be) - 1) * dev->csma_backoff_period;
-    csma_backoff_usec = base % csma_backoff_usec;
-    DEBUG("SET BACKOFF to %lu  be %u min %u max %u\n", csma_backoff_usec, be, dev->csma_minbe, dev->csma_maxbe);
+    csma_backoff_usec = base % csma_backoff_usec; // limit the 32bit random value to the current backoff
+    DEBUG("SET BACKOFF to %lu  be %u min %u max %u base: %lu\n", csma_backoff_usec, be, dev->csma_minbe, dev->csma_maxbe, base);
 
     dev->timer_msg.type = NETDEV_MSG_TYPE_EVENT;
     dev->timer_msg.sender_pid = thread_getpid();

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -1007,15 +1007,17 @@ static void _isr(netdev_t *netdev)
 
         bb_irq_mask &= ~BB_IRQ_RXFE;
 
+        if (dev->flags & AT86RF215_OPT_TELL_RX_END) {
+            /* will be executed in the same thread */
+            DEBUG("RX_COMPLETE CALLBACK\n");
+            netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
+        }
+
         if (rx_ack_req) {
             dev->state = AT86RF215_STATE_RX_SEND_ACK;
             break;
         }
 
-        if (dev->flags & AT86RF215_OPT_TELL_RX_END) {
-            /* will be executed in the same thread */
-            netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
-        }
 
         _set_idle(dev);
         break;
@@ -1027,11 +1029,6 @@ static void _isr(netdev_t *netdev)
         }
 
         bb_irq_mask &= ~BB_IRQ_TXFE;
-
-        if (dev->flags & AT86RF215_OPT_TELL_RX_END) {
-            /* will be executed in the same thread */
-            netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
-        }
 
         _set_idle(dev);
         break;

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -316,6 +316,11 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             }
             return sizeof(uint16_t);
 
+        case NETOPT_AUTOCCA:
+            *((netopt_enable_t *)val) =
+                !!(dev->flags & AT86RF215_OPT_CCATX);
+            return sizeof(netopt_enable_t);
+
         default:
             /* Can still be handled in second switch */
             break;
@@ -497,6 +502,12 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
         case NETOPT_AUTOACK:
             at86rf215_set_option(dev, AT86RF215_OPT_AUTOACK,
+                                 ((const bool *)val)[0]);
+            res = sizeof(netopt_enable_t);
+            break;
+
+        case NETOPT_AUTOCCA:
+            at86rf215_set_option(dev, AT86RF215_OPT_CCATX,
                                  ((const bool *)val)[0]);
             res = sizeof(netopt_enable_t);
             break;

--- a/drivers/at86rf215/at86rf215_o-qpsk.c
+++ b/drivers/at86rf215/at86rf215_o-qpsk.c
@@ -250,7 +250,7 @@ static void _set_legacy(at86rf215_t *dev, bool high_rate)
 
 static void _set_ack_timeout(at86rf215_t *dev, uint8_t chips, uint8_t mode)
 {
-    dev->ack_timeout_usec = 10 * AT86RF215_ACK_PERIOD_IN_BITS * 1000000UL / _get_bitrate(chips, mode);
+    dev->ack_timeout_usec = AT86RF215_ACK_PERIOD_IN_BITS * 1000000UL / _get_bitrate(chips, mode);
     DEBUG("[%s] ACK timeout: %"PRIu32" µs\n", "O-QPSK", dev->ack_timeout_usec);
 }
 

--- a/drivers/at86rf215/at86rf215_o-qpsk.c
+++ b/drivers/at86rf215/at86rf215_o-qpsk.c
@@ -254,6 +254,12 @@ static void _set_ack_timeout(at86rf215_t *dev, uint8_t chips, uint8_t mode)
     DEBUG("[%s] ACK timeout: %"PRIu32" µs\n", "O-QPSK", dev->ack_timeout_usec);
 }
 
+static void _set_csma_backoff_period(at86rf215_t *dev, uint8_t chips, uint8_t mode)
+{
+    dev->csma_backoff_period =  AT86RF215_BACKOFF_PERIOD_IN_BITS * 1000000UL / _get_bitrate(chips, mode);
+    DEBUG("[%s] CSMA BACKOFF: %"PRIu32" µs\n", "O-QPSK", dev->csma_backoff_period);
+}
+
 void _end_configure_OQPSK(at86rf215_t *dev)
 {
     /* set channel spacing */
@@ -301,6 +307,7 @@ int at86rf215_configure_OQPSK(at86rf215_t *dev, uint8_t chips, uint8_t mode)
 
     _set_mode(dev, mode);
     _set_chips(dev, chips);
+    _set_csma_backoff_period(dev, chips, mode);
     _set_ack_timeout(dev, chips, mode);
 
     _end_configure_OQPSK(dev);
@@ -320,6 +327,7 @@ int at86rf215_configure_legacy_OQPSK(at86rf215_t *dev, bool high_rate)
     at86rf215_reg_write(dev, dev->BBC->RG_PC, 0);
 
     _set_legacy(dev, high_rate);
+    _set_csma_backoff_period(dev, chips, mode);
     _set_ack_timeout(dev, chips, mode);
 
     _end_configure_OQPSK(dev);
@@ -341,6 +349,7 @@ int at86rf215_OQPSK_set_chips(at86rf215_t *dev, uint8_t chips)
     at86rf215_await_state_end(dev, RF_STATE_TX);
 
     _set_chips(dev, chips);
+    _set_csma_backoff_period(dev, chips, mode >> OQPSKPHRTX_MOD_SHIFT);
     _set_ack_timeout(dev, chips, mode >> OQPSKPHRTX_MOD_SHIFT);
 
     return 0;
@@ -366,6 +375,7 @@ int at86rf215_OQPSK_set_mode(at86rf215_t *dev, uint8_t mode)
     }
 
     _set_mode(dev, mode);
+    _set_csma_backoff_period(dev, chips, mode);
     _set_ack_timeout(dev, chips, mode);
 
     return 0;
@@ -390,6 +400,7 @@ int at86rf215_OQPSK_set_mode_legacy(at86rf215_t *dev, bool high_rate)
     uint8_t mode  = high_rate ? 3 : 2;
     uint8_t chips = is_subGHz(dev) ? BB_FCHIP1000 : BB_FCHIP2000;
 
+    _set_csma_backoff_period(dev, chips, mode);
     _set_ack_timeout(dev, chips, mode);
 
     return 0;

--- a/drivers/at86rf215/at86rf215_ofdm.c
+++ b/drivers/at86rf215/at86rf215_ofdm.c
@@ -218,6 +218,12 @@ static void _set_ack_timeout(at86rf215_t *dev, uint8_t option, uint8_t scheme)
     DEBUG("[%s] ACK timeout: %"PRIu32" µs\n", "OFDM", dev->ack_timeout_usec);
 }
 
+static void _set_csma_backoff_period(at86rf215_t *dev, uint8_t option, uint8_t scheme)
+{
+    dev->csma_backoff_period =  AT86RF215_BACKOFF_PERIOD_IN_BITS * 1000000UL / _get_bitrate(option, scheme);
+    DEBUG("[%s] CSMA BACKOFF: %"PRIu32" µs\n", "OFDM", dev->csma_backoff_period);
+}
+
 static bool _option_mcs_valid(uint8_t option, uint8_t mcs)
 {
     if (option < 1 || option > 4) {
@@ -261,6 +267,7 @@ int at86rf215_configure_OFDM(at86rf215_t *dev, uint8_t option, uint8_t scheme)
     at86rf215_reg_write(dev, dev->BBC->RG_OFDMPHRTX, scheme);
 
     _set_ack_timeout(dev, option, scheme);
+    _set_csma_backoff_period(dev, option, scheme);
 
     at86rf215_enable_radio(dev, BB_MROFDM);
 
@@ -282,6 +289,7 @@ int at86rf215_OFDM_set_scheme(at86rf215_t *dev, uint8_t scheme)
 
     at86rf215_reg_write(dev, dev->BBC->RG_OFDMPHRTX, scheme);
     _set_ack_timeout(dev, at86rf215_OFDM_get_option(dev), scheme);
+    _set_csma_backoff_period(dev, at86rf215_OFDM_get_option(dev), scheme);
 
     return 0;
 }
@@ -304,6 +312,7 @@ int at86rf215_OFDM_set_option(at86rf215_t *dev, uint8_t option)
 
     _set_option(dev, option);
     _set_ack_timeout(dev, option, mcs);
+    _set_csma_backoff_period(dev, option, mcs);
 
     return 0;
 }

--- a/drivers/at86rf215/include/at86rf215_internal.h
+++ b/drivers/at86rf215/include/at86rf215_internal.h
@@ -39,11 +39,19 @@ extern "C" {
 #define AT86RF215_RESET_DELAY           (16U)
 
 /**
+ * This is used to calculate the csma backoff based on the bitrate.
+*/
+/** 20 symbols is the std period length */
+#define AT86RF215_BACKOFF_PERIOD_IN_SYMBOLS (20U)
+/** in 802.15.4 oqpsk each symble is 4 bits, not about the others */
+#define AT86RF215_BACKOFF_PERIOD_IN_BITS    (AT86RF215_BACKOFF_PERIOD_IN_SYMBOLS * 4)
+
+/**
  * This is used to calculate the ACK timeout based on the bitrate.
  * AT86RF233 uses an ACK timeout of 54 symbol periods, or 864 µs @ 250 kbit/s
  * -> 864µs * 250kbit/s = 216 bit */
 #define AT86RF215_ACK_PERIOD_IN_SYMBOLS (54U)
-/** I'm not sure why according to the calculation, each symbol has 4 bits */
+/** in 802.15.4 oqpsk each symble is 4 bits, not about the others */
 #define AT86RF215_ACK_PERIOD_IN_BITS    (AT86RF215_ACK_PERIOD_IN_SYMBOLS * 4)
 
 #define AT86RF215_OQPSK_MODE_LEGACY           (0x1)                             /**< legacy mode, 250 kbit/s */

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -191,15 +191,6 @@ void at86rf215_reset_cfg(at86rf215_t *dev);
 void at86rf215_reset(at86rf215_t *dev);
 
 /**
- * @brief   Get the short address of the given device
- *
- * @param[in] dev           device to read from
- *
- * @return                  the currently set (2-byte) short address
- */
-uint16_t at86rf215_get_addr_short(const at86rf215_t *dev);
-
-/**
  * @brief   Get the short address of the given device form multi address filter
  *
  * @param[in] dev           device to read from
@@ -207,15 +198,7 @@ uint16_t at86rf215_get_addr_short(const at86rf215_t *dev);
  *
  * @return                  the currently set (2-byte) short address
  */
- uint16_t at86rf215_get_addr_short_multi(const at86rf215_t *dev, uint8_t filter);
-
-/**
- * @brief   Set the short address of the given device
- *
- * @param[in,out] dev       device to write to
- * @param[in] addr          (2-byte) short address to set
- */
-void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr);
+uint16_t at86rf215_get_addr_short(const at86rf215_t *dev, uint8_t filter);
 
 /**
  * @brief   Set the short address of the given device to multi address filter
@@ -224,9 +207,7 @@ void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr);
  * @param[in] filter          (1-byte) address filter to set
  * @param[in] addr          (2-byte) short address to set
  */
- void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t addr);
-
-
+void at86rf215_set_addr_short(at86rf215_t *dev, uint8_t filter, uint16_t addr);
 
 /**
  * @brief   Get whether frame filter is enabled or not
@@ -283,15 +264,6 @@ uint8_t at86rf215_get_chan(const at86rf215_t *dev);
 void at86rf215_set_chan(at86rf215_t *dev, uint16_t chan);
 
 /**
- * @brief   Get the configured PAN ID of the given device
- *
- * @param[in] dev           device to read from
- *
- * @return                  the currently set PAN ID
- */
-uint16_t at86rf215_get_pan(const at86rf215_t *dev);
-
-/**
  * @brief   Get the configured PAN ID of the given device from multi address filter
  *
  * @param[in] dev           device to read from
@@ -299,15 +271,7 @@ uint16_t at86rf215_get_pan(const at86rf215_t *dev);
  *
  * @return                  the currently set PAN ID
  */
- uint16_t at86rf215_get_pan_multi(const at86rf215_t *dev, uint8_t filter);
-
-/**
- * @brief   Set the PAN ID of the given device
- *
- * @param[in,out] dev       device to write to
- * @param[in] pan           PAN ID to set
- */
-void at86rf215_set_pan(at86rf215_t *dev, uint16_t pan);
+uint16_t at86rf215_get_pan(const at86rf215_t *dev, uint8_t filter);
 
 /**
  * @brief   Set the PAN ID of the given address filter
@@ -316,7 +280,7 @@ void at86rf215_set_pan(at86rf215_t *dev, uint16_t pan);
  * @param[in] filter        address filter to set
  * @param[in] pan           PAN ID to set
  */
- void at86rf215_set_pan_multi(at86rf215_t *dev, uint8_t filter, uint16_t pan);
+void at86rf215_set_pan(at86rf215_t *dev, uint8_t filter, uint16_t pan);
 
 /**
  * @brief   Get the configured transmission power of the given device [in dBm]

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -122,6 +122,14 @@ enum {
 /** @} */
 
 /**
+ * @name    Internal timeout flags
+ * @{
+ */
+#define AT86RF215_TIMEOUT_ACK        (0x0001)       /**< ACK timeout */
+#define AT86RF215_TIMEOUT_CSMA       (0x0002)       /**< CMSA timeout */
+/** @} */
+
+/**
  * @brief   struct holding all params needed for device initialization
  */
 typedef struct at86rf215_params {
@@ -144,13 +152,13 @@ typedef struct at86rf215 {
     struct at86rf215 *sibling;              /**< The other radio */
     const at86rf215_RF_regs_t  *RF;         /**< Radio Frontend Registers */
     const at86rf215_BBC_regs_t *BBC;        /**< Baseband Registers */
-    xtimer_t ack_timer;                     /**< timer for ACK timeout */
-    msg_t ack_msg;                          /**< message for ACK timeout */
+    xtimer_t timer;                         /**< timer for ACK & CSMA timeout */
+    msg_t timer_msg;                        /**< message for timeout timer */
     uint32_t ack_timeout_usec;              /**< time to wait before retransmission in µs */
     uint16_t flags;                         /**< Device specific flags */
     uint16_t num_chans;                     /**< Number of legal channel at current modulation */
     uint16_t tx_frame_len;                  /**< length of the current TX frame */
-    uint8_t ack_timeout;                    /**< 1 if ack timeout was reached, 0 otherwise */
+    uint8_t timeout;                        /**< indicates which timeout was reached */
     uint8_t mode;                           /**< current phy mode */
     uint8_t state;                          /**< current state of the radio */
     uint8_t retries_max;                    /**< number of retries until ACK is received */
@@ -160,9 +168,6 @@ typedef struct at86rf215 {
     uint8_t fsk_pl_rx;                      /**< FSK Preamble Length for RX */
     uint8_t fsk_pl_tx;                      /**< FSK Preamble Length for TX */
     uint32_t csma_backoff_period;           /**< CSMA Backoff period */
-    uint32_t csma_backoff_usec;             /**< active CSMA Backoff */
-    xtimer_t backoff_timer;                 /**< timer for csma backoff  */
-    uint8_t backoff_timeout;                    /**< 1 if ack timeout was reached, 0 otherwise */
     uint8_t csma_minbe;                     /**< CSMA mininum backoff exponent */
     uint8_t csma_maxbe;                     /**< CSMA maximum backoff exponent */
 } at86rf215_t;

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -159,6 +159,12 @@ typedef struct at86rf215 {
     uint8_t csma_retries;                   /**< CSMA retries left */
     uint8_t fsk_pl_rx;                      /**< FSK Preamble Length for RX */
     uint8_t fsk_pl_tx;                      /**< FSK Preamble Length for TX */
+    uint32_t csma_backoff_period;           /**< CSMA Backoff period */
+    uint32_t csma_backoff_usec;             /**< active CSMA Backoff */
+    xtimer_t backoff_timer;                 /**< timer for csma backoff  */
+    uint8_t backoff_timeout;                    /**< 1 if ack timeout was reached, 0 otherwise */
+    uint8_t csma_minbe;                     /**< CSMA mininum backoff exponent */
+    uint8_t csma_maxbe;                     /**< CSMA maximum backoff exponent */
 } at86rf215_t;
 
 /**

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -215,19 +215,27 @@ void at86rf215_set_addr_short(at86rf215_t *dev, uint8_t filter, uint16_t addr);
  * @param[in] dev           device to read from
  * @param[in] filter        (1-byte) filter to get
  *
- * @return                  the current state of the filter
+ * @return                  (bool) the current state of the filter
  */
-uint8_t at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter);
+bool at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter);
 
 /**
- * @brief   Get whether frame filter is enabled or not
+ * @brief   Enables frame filter <filter>
  *
  * @param[in] dev           device to read from
  * @param[in] filter        (1-byte) filter to get
- * @param[in] state         (1-byte) state of filter
  *
  */
-void at86rf215_set_framefilter_enabled(at86rf215_t *dev, uint8_t filter, uint8_t state);
+ void at86rf215_disable_framefilter(at86rf215_t *dev, uint8_t filter);
+
+/**
+ * @brief   Disables frame filter <filter>
+ *
+ * @param[in] dev           device to read from
+ * @param[in] filter        (1-byte) filter to get
+ *
+ */
+void at86rf215_enable_framefilter(at86rf215_t *dev, uint8_t filter);
 
 /**
  * @brief   Get the configured long address of the given device

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -193,12 +193,31 @@ void at86rf215_reset(at86rf215_t *dev);
 uint16_t at86rf215_get_addr_short(const at86rf215_t *dev);
 
 /**
+ * @brief   Get the short address of the given device form multi address filter
+ *
+ * @param[in] dev           device to read from
+ * @param[in] filter        address filter to read 
+ *
+ * @return                  the currently set (2-byte) short address
+ */
+ uint16_t at86rf215_get_addr_short_multi(const at86rf215_t *dev, uint8_t filter);
+
+/**
  * @brief   Set the short address of the given device
  *
  * @param[in,out] dev       device to write to
  * @param[in] addr          (2-byte) short address to set
  */
 void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr);
+
+/**
+ * @brief   Set the short address of the given device to multi address filter
+ *
+ * @param[in,out] dev       device to write to
+ * @param[in] addr          (1-byte) address filter to set
+ * @param[in] addr          (2-byte) short address to set
+ */
+ void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t addr);
 
 /**
  * @brief   Get the configured long address of the given device
@@ -244,12 +263,31 @@ void at86rf215_set_chan(at86rf215_t *dev, uint16_t chan);
 uint16_t at86rf215_get_pan(const at86rf215_t *dev);
 
 /**
+ * @brief   Get the configured PAN ID of the given device from multi address filter
+ *
+ * @param[in] dev           device to read from
+ * @param[in] filter        address filter to read from
+ *
+ * @return                  the currently set PAN ID
+ */
+ uint16_t at86rf215_get_pan_multi(const at86rf215_t *dev, uint8_t filter);
+
+/**
  * @brief   Set the PAN ID of the given device
  *
  * @param[in,out] dev       device to write to
  * @param[in] pan           PAN ID to set
  */
 void at86rf215_set_pan(at86rf215_t *dev, uint16_t pan);
+
+/**
+ * @brief   Set the PAN ID of the given address filter
+ *
+ * @param[in,out] dev       device to write to
+ * @param[in] filter        address filter to set
+ * @param[in] pan           PAN ID to set
+ */
+ void at86rf215_set_pan_multi(at86rf215_t *dev, uint8_t filter, uint16_t pan);
 
 /**
  * @brief   Get the configured transmission power of the given device [in dBm]

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -118,6 +118,7 @@ enum {
 #define AT86RF215_OPT_TX_PENDING     (0x0400)       /**< Frame is loaded into TX buffer */
 #define AT86RF215_OPT_CCA_PENDING    (0x0800)       /**< CCA needs to be done for the current frame */
 #define AT86RF215_OPT_RPC            (0x1000)       /**< Enable Reduced Power Consumption */
+#define AT86RF215_OPT_CCATX          (0x2000)       /**< TX after CCA performd automatically */
 /** @} */
 
 /**

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -214,10 +214,32 @@ void at86rf215_set_addr_short(at86rf215_t *dev, uint16_t addr);
  * @brief   Set the short address of the given device to multi address filter
  *
  * @param[in,out] dev       device to write to
- * @param[in] addr          (1-byte) address filter to set
+ * @param[in] filter          (1-byte) address filter to set
  * @param[in] addr          (2-byte) short address to set
  */
  void at86rf215_set_addr_short_multi(at86rf215_t *dev, uint8_t filter, uint16_t addr);
+
+
+
+/**
+ * @brief   Get whether frame filter is enabled or not
+ *
+ * @param[in] dev           device to read from
+ * @param[in] filter        (1-byte) filter to get
+ *
+ * @return                  the current state of the filter
+ */
+uint8_t at86rf215_get_framefilter_enabled(at86rf215_t *dev, uint8_t filter);
+
+/**
+ * @brief   Get whether frame filter is enabled or not
+ *
+ * @param[in] dev           device to read from
+ * @param[in] filter        (1-byte) filter to get
+ * @param[in] state         (1-byte) state of filter
+ *
+ */
+void at86rf215_set_framefilter_enabled(at86rf215_t *dev, uint8_t filter, uint8_t state);
 
 /**
  * @brief   Get the configured long address of the given device


### PR DESCRIPTION
### Contribution description
There were some issues regarding timings, standard conformity and CCA, and other minor things.

- the at86rf215 can filter for several short addresses, as I need that feature I added functions to use these filters
- short addresses had to be given in opposite byte order than pan addresses and also in the opposite order of the addresses in the frames, switched byte order of short addresses while setting registers
- ack-timeout was 8,64ms, the standard says it should be 864us for the chosen modulation (oqpsk 250kbps)
- rx_complete callback is called before the ACK transmission is finished. The ACK transmission does not need any CPU time, therefore the frame can be handled by the CPU while the ACK is transmitted. Speeds up communication a lot, ~1ms per frame.
- added feature to make use of the CCATX feature of the radio, it performs the CCA and transmits autocratically if channel is free. Minimizes interrupts and speeds up communication, ~0.5ms per frame. Feature is selected by enabling NETOPT_AUTOCCA
- CCA was not working, The datasheet does not state that AMCS.CCAED is altered by performing manual EDs, therefore the medium was always considered free. Now RFn_EDV is compared to 
 BBCn_AMEDT in software. If CCATX is used this is not necessary as AMCS.CCAED is altered in this mode. I tested this with a jammer.
- added random exponential backoff timer for CSMA and the configuration stuff for it.

